### PR TITLE
Pass event into addNewFoodsToMeal function for browser compatability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ const updateNodeValue = (node, value) => {
   $(node.find('strong')[0]).text(value)
 }
 
-const addNewFoodsToMeal = () => {
+const addNewFoodsToMeal = (event) => {
   var checkedFoods = $('.food-item-checkbox:checkbox:checked')
   checkedFoods.each(index => {
     var food = setFoodData(checkedFoods[index])


### PR DESCRIPTION
#### Pivotal URL: N/A

#### What does this PR do?
Fixes an issue where the event object was not passed into the `addNewFoodsToMeal` handler in `lib/index.js`, causing the application to break in Firefox. Specifically when trying to add a new food to a meal. 

#### Where should the reviewer start?
Only change is on `lib/index.js` on line 135

#### Any additional context you want to provide?
N/A

#### Screenshots (if appropriate)
N/A